### PR TITLE
fix: more packages added to export-package in manifest

### DIFF
--- a/src/main/resources/META-INF/MANIFEST.MF
+++ b/src/main/resources/META-INF/MANIFEST.MF
@@ -10,4 +10,7 @@ Require-Bundle: com.polarion.portal.tomcat,
  org.springframework.spring-web,
  org.apache.commons.logging,
  org.apache.hivemind
-Export-Package: ch.sbb.polarion.extension.interceptor_manager
+Export-Package: ch.sbb.polarion.extension.interceptor_manager,
+ ch.sbb.polarion.extension.interceptor_manager.model,
+ ch.sbb.polarion.extension.interceptor_manager.settings,
+ ch.sbb.polarion.extension.interceptor_manager.util


### PR DESCRIPTION
Refs: #69

### Proposed changes

When developing a hook in Eclipse, users get a warning that the classes in the subpackage model and settings are not considered API and access is discouraged. Export-Package should also include ch.sbb.polarion.extension.interceptor_manager.model, ch.sbb.polarion.extension.interceptor_manager.settings, and ch.sbb.polarion.extension.interceptor_manager.util to avoid the error message.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
