### PR TITLE
feat: optional custom settings validation

### DIFF
--- a/src/main/java/ch/sbb/polarion/extension/interceptor_manager/model/ActionHook.java
+++ b/src/main/java/ch/sbb/polarion/extension/interceptor_manager/model/ActionHook.java
@@ -93,6 +93,16 @@ public abstract class ActionHook {
     @JsonIgnore
     public abstract String getDefaultSettings();
 
+
+    /**
+     * Called each time the settings are updated in the administration panel.
+     *
+     * @return null if the settings are valid and an error message if the settings are invalid (it will be displayed to the user)
+     */
+    public String validateSettings(HookModel model) {
+        return null;
+    }
+
     @NotNull
     protected String getSettingsValue(@NotNull String settingsId, String... selectors) {
         LinkedHashMap<String, String> valueMap = getSettingsValuesWithSelector(settingsId, selectors);

--- a/src/main/java/ch/sbb/polarion/extension/interceptor_manager/model/ActionHook.java
+++ b/src/main/java/ch/sbb/polarion/extension/interceptor_manager/model/ActionHook.java
@@ -99,6 +99,7 @@ public abstract class ActionHook {
      *
      * @return null if the settings are valid and an error message if the settings are invalid (it will be displayed to the user)
      */
+    @SuppressWarnings("java:S1172") // parameter 'model' will be used by subclasses
     public String validateSettings(HookModel model) {
         return null;
     }

--- a/src/main/java/ch/sbb/polarion/extension/interceptor_manager/settings/HookSettings.java
+++ b/src/main/java/ch/sbb/polarion/extension/interceptor_manager/settings/HookSettings.java
@@ -1,8 +1,12 @@
 package ch.sbb.polarion.extension.interceptor_manager.settings;
 
 import ch.sbb.polarion.extension.generic.settings.GenericNamedSettings;
+import ch.sbb.polarion.extension.generic.settings.SettingsService;
 import ch.sbb.polarion.extension.interceptor_manager.model.ActionHook;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.VisibleForTesting;
+
+import java.util.Optional;
 
 public class HookSettings extends GenericNamedSettings<HookModel> {
     private final ActionHook hook;
@@ -12,9 +16,18 @@ public class HookSettings extends GenericNamedSettings<HookModel> {
         this.hook = hook;
     }
 
+    @VisibleForTesting
+    public HookSettings(ActionHook hook, SettingsService settingsService) {
+        super(hook.getName(), settingsService);
+        this.hook = hook;
+    }
+
     @Override
     public void beforeSave(@NotNull HookModel what) {
         what.setHookVersion(hook.getVersion());
+        Optional.ofNullable(hook.validateSettings(what)).ifPresent(error -> {
+            throw new IllegalArgumentException(error);
+        });
     }
 
     @Override

--- a/src/main/resources/webapp/interceptor-manager-admin/js/settings.js
+++ b/src/main/resources/webapp/interceptor-manager-admin/js/settings.js
@@ -28,7 +28,17 @@ function saveSettings() {
             SbbCommon.setNewerVersionNotificationVisible(false);
             readAndFillRevisions();
         },
-        onError: () => SbbCommon.showSaveErrorAlert()
+        onError: (status, errorMessage) => {
+            if (errorMessage) {
+                SbbCommon.showActionAlert({
+                    containerId: 'action-error',
+                    message: errorMessage,
+                    hideAlertByTimeout: false
+                });
+            } else {
+                SbbCommon.showSaveErrorAlert()
+            }
+        }
     });
 }
 

--- a/src/test/java/ch/sbb/polarion/extension/interceptor_manager/settings/HookSettingsTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/interceptor_manager/settings/HookSettingsTest.java
@@ -1,0 +1,32 @@
+package ch.sbb.polarion.extension.interceptor_manager.settings;
+
+import ch.sbb.polarion.extension.generic.settings.SettingsService;
+import ch.sbb.polarion.extension.interceptor_manager.model.ActionHook;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class HookSettingsTest {
+
+    @Test
+    public void testValidate() {
+        ActionHook hook = mock(ActionHook.class);
+
+        HookModel hookModel = mock(HookModel.class);
+        HookSettings settings = new HookSettings(hook, mock(SettingsService.class));
+
+        settings.beforeSave(hookModel);
+        verify(hook, times(1)).validateSettings(any());
+
+        when(hook.validateSettings(any())).thenReturn("Some validation error");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> settings.beforeSave(hookModel));
+        assertEquals("Some validation error", exception.getMessage());
+        verify(hook, times(2)).validateSettings(any());
+    }
+}


### PR DESCRIPTION
Refs: #91

### Proposed changes

To avoid invalid settings, the interceptor manager could call an optional method String validateSettings(Map<String, String> propertiesMap) of the hook each time its settings are updated in the administration panel. The method returns null if the settings are valid and a message if the settings are invalid.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
