### PR TITLE
fix: recalculate newer plugin version warning visibility when selecti…

### DIFF
--- a/src/main/resources/webapp/interceptor-manager-admin/js/settings.js
+++ b/src/main/resources/webapp/interceptor-manager-admin/js/settings.js
@@ -159,8 +159,8 @@ function parseAndSetSettings(text, checkNewerVersion) {
     const settings = JSON.parse(text);
     SbbCommon.setCheckboxValueById('enable-hook', settings.enabled);
     SbbCommon.setValueById('properties-input', settings.properties);
-    if (checkNewerVersion && settings.hookVersion !== Hooks.selectedHook.version) {
-        SbbCommon.setNewerVersionNotificationVisible(true);
+    if (checkNewerVersion) {
+        SbbCommon.setNewerVersionNotificationVisible(settings.hookVersion !== Hooks.selectedHook.version);
     }
 }
 


### PR DESCRIPTION
…ng another hook

Refs: #98

### Proposed changes

When selecting a hook in the admin panel that has been updated since last editing the configuration settings, a warning appears. When selecting a different hook that has not been updated, the warning does not disappear.
This fix solves the issue above recalculating the visibility of warning on hook selection.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
