### PR TITLE
feat: align admin UI with Polarion 2606 theme

### DIFF
--- a/src/main/resources/webapp/interceptor-manager-admin/css/interceptor-manager-admin.css
+++ b/src/main/resources/webapp/interceptor-manager-admin/css/interceptor-manager-admin.css
@@ -9,7 +9,7 @@
 #hooks-reload-button {
     background: none !important;
     border: none;
-    color: #069;
+    color: #007993;
     text-decoration: underline;
     cursor: pointer;
 }
@@ -28,7 +28,7 @@
 }
 
 #hooks-choose-container label {
-    border: 1px solid #004D73;
+    border: 1px solid #DEDEDE;
     padding: 10px;
     cursor: pointer;
 }
@@ -37,7 +37,7 @@
     font-size: 13px;
     margin-bottom: 10px;
     padding: 16px 4px 16px 36px;
-    background: #D8E4F1 url("/polarion/ria/images/msginfo.png") 10px 18px no-repeat;
+    background: #E5F2F4 url("/polarion/ria/images/msginfo.png") 10px 18px no-repeat;
 }
 
 #enable-hook-label {


### PR DESCRIPTION
### Proposed changes

Recolor the admin pane to the 2606 neutral/teal theme: reload link to #007993, label border to #DEDEDE, info box background to #E5F2F4.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
