### PR TITLE
build: update react-sbb-polarion to 0.1.0

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8,7 +8,7 @@
       "name": "interceptor-manager-app",
       "version": "1.0.0",
       "dependencies": {
-        "@grigoriev/react-sbb-polarion": "^0.0.13",
+        "@grigoriev/react-sbb-polarion": "^0.1.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "sonner": "^2.0.7"
@@ -36,7 +36,7 @@
         "vitest-browser-react": "2.2.0"
       },
       "engines": {
-        "node": "^22.22.2 || ^24.15.0 || >=26.0.0",
+        "node": "^24.15.0 || >=26.0.0",
         "npm": ">=12"
       }
     },
@@ -510,12 +510,12 @@
       }
     },
     "node_modules/@grigoriev/react-sbb-polarion": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/@grigoriev/react-sbb-polarion/-/react-sbb-polarion-0.0.13.tgz",
-      "integrity": "sha512-UgXYcGoaIxbmbWs4IQFzYmZB8CqEb4UoapE+zDEchsMw8n620WCcvtYhVZb93Ai/3zZXkv9jx6tmjUqs4LnJXQ==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@grigoriev/react-sbb-polarion/-/react-sbb-polarion-0.1.0.tgz",
+      "integrity": "sha512-M3t7fEv5uWUAt3y/RKksZmJeVIRaDwJfNUMkHfuR6UdFtcbMQ+2g2Umr/6+T3AMU6ag8sOWt0aidAfe9E9XMlw==",
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=20.9.0",
+        "node": ">=24.0.0",
         "npm": ">=11"
       },
       "peerDependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -21,7 +21,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@grigoriev/react-sbb-polarion": "^0.0.13",
+    "@grigoriev/react-sbb-polarion": "^0.1.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "sonner": "^2.0.7"
@@ -49,7 +49,7 @@
     "vitest-browser-react": "2.2.0"
   },
   "engines": {
-    "node": "^22.22.2 || ^24.15.0 || >=26.0.0",
+    "node": "^24.15.0 || >=26.0.0",
     "npm": ">=12"
   },
   "packageManager": "npm@12.0.1",


### PR DESCRIPTION
Updates `@grigoriev/react-sbb-polarion` from the previously pinned `0.0.x` to `0.1.0`.

The release adds a multi-select mode to `SearchableSelect` (additive; nothing here uses it yet) and
raises the library's own node floor to 24. The `engines.node` range drops its `^22.22.2` branch
accordingly, so the declared range no longer permits a runtime the library rejects.

Verified per repo: `format:check`, `lint`, `build`, and `test:coverage:docker` (behaviour + visual
regression + the coverage gate) all green.
